### PR TITLE
Feat: 채팅 관리 기능 및 AI 모델 연동 구현

### DIFF
--- a/src/main/java/org/example/showroom/talk/controller/TalkController.java
+++ b/src/main/java/org/example/showroom/talk/controller/TalkController.java
@@ -1,0 +1,41 @@
+
+package org.example.showroom.talk.controller;
+
+import org.example.showroom.talk.dto.TalkRequestDto;
+import org.example.showroom.talk.dto.TalkResponseDto;
+import org.example.showroom.talk.service.TalkService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/talks")
+public class TalkController {
+
+    private final TalkService talkService;
+
+    @Autowired
+    public TalkController(TalkService talkService) {
+        this.talkService = talkService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TalkResponseDto> createTalk(@RequestBody TalkRequestDto talkRequestDto) {
+        TalkResponseDto savedTalk = talkService.saveTalk(talkRequestDto);
+        return ResponseEntity.ok(savedTalk);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TalkResponseDto>> getAllTalks() {
+        List<TalkResponseDto> talks = talkService.getAllTalks();
+        return ResponseEntity.ok(talks);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTalk(@PathVariable Long id) {
+        talkService.deleteTalk(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/example/showroom/talk/dto/TalkRequestDto.java
+++ b/src/main/java/org/example/showroom/talk/dto/TalkRequestDto.java
@@ -1,0 +1,11 @@
+
+package org.example.showroom.talk.dto;
+
+import lombok.Data;
+
+@Data
+public class TalkRequestDto {
+
+    private String memberId;
+    private String text;
+}

--- a/src/main/java/org/example/showroom/talk/dto/TalkResponseDto.java
+++ b/src/main/java/org/example/showroom/talk/dto/TalkResponseDto.java
@@ -1,0 +1,14 @@
+
+package org.example.showroom.talk.dto;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class TalkResponseDto {
+
+    private Long id;
+    private String memberId;
+    private String text;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/showroom/talk/entity/Talk.java
+++ b/src/main/java/org/example/showroom/talk/entity/Talk.java
@@ -1,0 +1,45 @@
+package org.example.showroom.talk.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Talk {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String memberId;
+
+    @Column(nullable = false, length = 1000)
+    private String text;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public Talk(String memberId, String text) {
+        this.memberId = memberId;
+        this.text = text;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 테스트 전용 생성자 (권장하지 않음)
+    protected Talk(String memberId, String text, LocalDateTime createdAt) {
+        this.memberId = memberId;
+        this.text = text;
+        this.createdAt = createdAt;
+    }
+
+    // 필요한 경우 특정 필드를 업데이트할 메서드를 제공
+    public void updateText(String newText) {
+        this.text = newText;
+    }
+
+}

--- a/src/main/java/org/example/showroom/talk/repository/TalkRepository.java
+++ b/src/main/java/org/example/showroom/talk/repository/TalkRepository.java
@@ -1,0 +1,17 @@
+package org.example.showroom.talk.repository;
+
+import org.example.showroom.talk.entity.Talk;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+public interface TalkRepository extends JpaRepository<Talk, Long> {
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM Talk t WHERE t.createdAt < :expiryDate")
+    void deleteTalksOlderThan(LocalDateTime expiryDate);
+}

--- a/src/main/java/org/example/showroom/talk/service/TalkCleanupService.java
+++ b/src/main/java/org/example/showroom/talk/service/TalkCleanupService.java
@@ -1,0 +1,26 @@
+package org.example.showroom.talk.service;
+
+import org.example.showroom.talk.repository.TalkRepository;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@EnableScheduling
+public class TalkCleanupService {
+
+    private final TalkRepository talkRepository;
+
+    public TalkCleanupService(TalkRepository talkRepository) {
+        this.talkRepository = talkRepository;
+    }
+
+    // 매일 자정에 1주일 이상 된 메시지 삭제
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void cleanUpOldTalks() {
+        LocalDateTime expiryDate = LocalDateTime.now().minusWeeks(1);
+        talkRepository.deleteTalksOlderThan(expiryDate);
+    }
+}

--- a/src/main/java/org/example/showroom/talk/service/TalkService.java
+++ b/src/main/java/org/example/showroom/talk/service/TalkService.java
@@ -1,0 +1,48 @@
+
+package org.example.showroom.talk.service;
+
+import org.example.showroom.talk.dto.TalkRequestDto;
+import org.example.showroom.talk.dto.TalkResponseDto;
+import org.example.showroom.talk.entity.Talk;
+import org.example.showroom.talk.repository.TalkRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TalkService {
+
+    private final TalkRepository talkRepository;
+
+    @Autowired
+    public TalkService(TalkRepository talkRepository) {
+        this.talkRepository = talkRepository;
+    }
+
+    public TalkResponseDto saveTalk(TalkRequestDto talkRequestDto) {
+        Talk talk = new Talk(talkRequestDto.getMemberId(), talkRequestDto.getText());
+        Talk savedTalk = talkRepository.save(talk);
+        return mapToResponseDto(savedTalk);
+    }
+
+    public List<TalkResponseDto> getAllTalks() {
+        return talkRepository.findAll().stream()
+                .map(this::mapToResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteTalk(Long id) {
+        talkRepository.deleteById(id);
+    }
+
+    private TalkResponseDto mapToResponseDto(Talk talk) {
+        TalkResponseDto responseDto = new TalkResponseDto();
+        responseDto.setId(talk.getId());
+        responseDto.setMemberId(talk.getMemberId());
+        responseDto.setText(talk.getText());
+        responseDto.setCreatedAt(talk.getCreatedAt());
+        return responseDto;
+    }
+}

--- a/src/test/java/org/example/showroom/talk/service/TalkCleanupServiceTest.java
+++ b/src/test/java/org/example/showroom/talk/service/TalkCleanupServiceTest.java
@@ -1,0 +1,64 @@
+package org.example.showroom.talk.service;
+
+import org.example.showroom.talk.entity.Talk;
+import org.example.showroom.talk.repository.TalkRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class TalkCleanupServiceTest {
+
+    @Autowired
+    private TalkCleanupService talkCleanupService;
+
+    @Autowired
+    private TalkRepository talkRepository;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // 테스트 데이터 추가
+        Talk oldTalk = new Talk("user1", "Old message");
+        setField(oldTalk, "createdAt", LocalDateTime.now().minusWeeks(2)); // Reflection으로 필드 설정
+        talkRepository.save(oldTalk);
+
+        Talk recentTalk = new Talk("user2", "Recent message");
+        setField(recentTalk, "createdAt", LocalDateTime.now());
+        talkRepository.save(recentTalk);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // 테스트 후 데이터 정리
+        talkRepository.deleteAll();
+    }
+
+    @Test
+    public void testCleanUpOldTalks() {
+        // 초기 데이터 확인
+        List<Talk> allTalks = talkRepository.findAll();
+        assertThat(allTalks).hasSize(2);
+
+        // 1주일 이상 된 메시지 삭제
+        talkCleanupService.cleanUpOldTalks();
+
+        // 삭제 후 데이터 확인
+        List<Talk> remainingTalks = talkRepository.findAll();
+        assertThat(remainingTalks).hasSize(1);
+        assertThat(remainingTalks.get(0).getText()).isEqualTo("Recent message");
+    }
+
+    private void setField(Talk talk, String fieldName, LocalDateTime value) throws Exception {
+        Field field = Talk.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(talk, value);
+    }
+}


### PR DESCRIPTION
- 채팅 메시지 관리를 위한 Talk 엔티티, 레포지토리, 서비스 클래스 추가
- 채팅 작업을 위한 REST API 엔드포인트를 관리하는 TalkController 구현
- 요청 및 응답 처리를 위한 DTO 클래스(TalkRequestDto, TalkResponseDto) 생성
- 오래된 채팅 메시지를 주기적으로 정리하는 TalkCleanupService 추가
- 정리 기능을 테스트하기 위한 TalkCleanupServiceTest 작성
- Swagger 의존성 추가를 위한 build.gradle 수정